### PR TITLE
Fix #7 + fix minimum/maximum date on Android + add some functions

### DIFF
--- a/demo/app/app.component.html
+++ b/demo/app/app.component.html
@@ -2,12 +2,15 @@
     <Calendar #calendar backgroundColor="#686B74" row="0" [settings]="settings" [events]="events" [appearance]="appearance" (dateSelected)="dateSelected($event)"
         (monthChanged)="monthChanged($event)" (displayModeChanged)='displayModeChanged($event)' (loaded)="calendarLoaded($event)">
     </Calendar>
-    <StackLayout #layout row="1" orientation="vertical" (loaded)="layoutLoaded($event)">
+    <StackLayout #layout row="1" orientation="vertical" (loaded)="layoutLoaded($event)" verticalAlignment="middle" class="actions">
         <Button (tap)="changeOrientation()" text="change scroll orientation" class="btn"></Button>
         <Button (tap)="changeDisplayMode()" text="change to week/month mode" class="btn"></Button>
         <Button (tap)="changeFirstWeekDay()" text="change first week day" class="btn"></Button>
         <Button (tap)="changeSelectionMode()" text="change to single/multiple selection" class="btn"></Button>
         <Button (tap)="changeAppearance()" text="change appearance" class="btn"></Button>
         <Button (tap)="changeEvents()" text="change events" class="btn"></Button>
+        <Button (tap)="selectDate()" text="select date programmatically" class="btn" [visibility]="(!dateProgrammaticallySelected) ? 'visible' : 'collapse'"></Button>
+        <Button (tap)="deselectDate()" text="deselect date programmatically" class="btn" [visibility]="(dateProgrammaticallySelected) ? 'visible' : 'collapse'"></Button>
+
     </StackLayout>
 </GridLayout>

--- a/demo/app/app.component.ts
+++ b/demo/app/app.component.ts
@@ -11,7 +11,7 @@ import {
 } from 'nativescript-fancy-calendar';
 import { registerElement } from 'nativescript-angular';
 import { Color } from "color";
-import { isIOS } from "platform";
+import { isIOS, isAndroid } from "platform";
 import { AnimationCurve } from "ui/enums";
 
 declare const NSDate, UIView, UIViewAnimationOptions;
@@ -199,6 +199,13 @@ export class AppComponent {
 
     public dateSelected(event) {
         console.log('date selected');
+        let date: Date;
+        if (isIOS) {
+          date = event.data;
+        } else if (isAndroid) {
+          date = event.data.date;
+        }
+        console.log('===> ' + date);
     }
 
 

--- a/demo/app/app.component.ts
+++ b/demo/app/app.component.ts
@@ -31,6 +31,7 @@ export class AppComponent {
     subtitles: CalendarSubtitle[];
     events: CalendarEvent[];
     public appearance: Appearance;
+    public dateProgrammaticallySelected: boolean;
     private _calendar: Calendar;
     private _layout: any;
 
@@ -211,6 +212,26 @@ export class AppComponent {
 
     public monthChanged(event) {
         console.log('month selected');
+    }
+
+    selectDate() {
+        // select tomorrow
+        let temp = new Date();
+        let tommorow = new Date().getDate() + 1;
+        temp.setDate(tommorow);
+        console.log('select tomorrow : ' + temp);
+        this._calendar.selectDate(temp);
+        this.dateProgrammaticallySelected = true;
+    }
+
+    deselectDate() {
+        // select tomorrow
+        let temp = new Date();
+        let tommorow = new Date().getDate() + 1;
+        temp.setDate(tommorow);
+        console.log('deselect tomorrow');
+        this._calendar.deselectDate(temp);
+        this.dateProgrammaticallySelected = false;
     }
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -37,7 +37,6 @@ export declare class Calendar extends CalendarBase {
     private _delegate;
     private _dataSource;
     private _calendarHeightConstraint;
-    private _date;
     constructor();
     readonly ios: any;
     onLoaded(): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -37,6 +37,7 @@ export declare class Calendar extends CalendarBase {
     private _delegate;
     private _dataSource;
     private _calendarHeightConstraint;
+    private _date;
     constructor();
     readonly ios: any;
     onLoaded(): void;
@@ -52,4 +53,7 @@ export declare class Calendar extends CalendarBase {
     private isSameDate(dateOne, dateTwo);
     reload(): void;
     displayModeChanged(bounds: any): void;
+    selectDate(date: any): void;
+    deselectDate(date: any): void;
+    getDate(): any;
 }

--- a/src/android/calendar.d.ts
+++ b/src/android/calendar.d.ts
@@ -1,9 +1,13 @@
 import { CalendarBase } from "../common";
 export declare class Calendar extends CalendarBase {
+    private _date;
     readonly android: any;
     createNativeView(): any;
     private addDecoratorToday(date, colorBackgroundValue, colorSelectionValue, borderRadiusValue);
     private addDecoratorDot(colorValue);
     dateHasEvent(date: any): boolean;
     private isSameDate(dateOne, dateTwo);
+    selectDate(date: Date): void;
+    deselectDate(date: Date): void;
+    getDate(): Date;
 }

--- a/src/android/calendar.d.ts
+++ b/src/android/calendar.d.ts
@@ -1,6 +1,5 @@
 import { CalendarBase } from "../common";
 export declare class Calendar extends CalendarBase {
-    private _date;
     readonly android: any;
     createNativeView(): any;
     private addDecoratorToday(date, colorBackgroundValue, colorSelectionValue, borderRadiusValue);
@@ -9,5 +8,4 @@ export declare class Calendar extends CalendarBase {
     private isSameDate(dateOne, dateTwo);
     selectDate(date: Date): void;
     deselectDate(date: Date): void;
-    getDate(): Date;
 }

--- a/src/android/calendar.ts
+++ b/src/android/calendar.ts
@@ -26,7 +26,6 @@ const MaterialCalendar = com.prolificinteractive.materialcalendarview,
 
 
 export class Calendar extends CalendarBase {
-    private _date: Date;
 
     public get android() {
         return this.nativeView;
@@ -230,9 +229,5 @@ export class Calendar extends CalendarBase {
 
     public deselectDate(date: Date) {
         this.nativeView.setDateSelected(new MaterialCalendarDay(date.getFullYear(), date.getMonth(), date.getDate()), false);
-    }
-
-    public getDate() {
-        return this._date;
     }
 }

--- a/src/android/calendar.ts
+++ b/src/android/calendar.ts
@@ -26,6 +26,7 @@ const MaterialCalendar = com.prolificinteractive.materialcalendarview,
 
 
 export class Calendar extends CalendarBase {
+    private _date: Date;
 
     public get android() {
         return this.nativeView;
@@ -55,10 +56,11 @@ export class Calendar extends CalendarBase {
                 return _that.get();
             },
             onDateSelected: function (widget, date, selected) {
+                let dateISO = new Date(date.getYear(), date.getMonth(), date.getDay());
                 this.owner.notify({
                     eventName: NSEvents.dateSelected,
                     object: _that,
-                    data: { date: date, selected: selected }
+                    data: { date: dateISO, selected: selected }
                 });
             }
         });
@@ -70,10 +72,11 @@ export class Calendar extends CalendarBase {
                 return _that.get();
             },
             onMonthChanged: function (widget, date) {
+                let dateISO = new Date(date.getYear(), date.getMonth(), date.getDay());
                 this.owner.notify({
                     eventName: NSEvents.monthChanged,
                     object: _that,
-                    data: date
+                    data: dateISO
                 });
             }
         });
@@ -124,14 +127,18 @@ export class Calendar extends CalendarBase {
             .commit();
 
         let calendarMaxDate = newSettings.maximumDate;
-        this.nativeView.state().edit()
-            .setMaximumDate(new MaterialCalendarDay(calendarMaxDate.getFullYear(), calendarMaxDate.getMonth(), calendarMaxDate.getDate()))
-            .commit();
+        if (calendarMaxDate) {
+            this.nativeView.state().edit()
+                .setMaximumDate(new MaterialCalendarDay(calendarMaxDate.getFullYear(), calendarMaxDate.getMonth(), calendarMaxDate.getDate()))
+                .commit();
+        }
 
         let calendarMinDate = newSettings.minimumDate;
-        this.nativeView.state().edit()
-            .setMinimumDate(new MaterialCalendarDay(calendarMinDate.getFullYear(), calendarMinDate.getMonth(), calendarMinDate.getDate()))
-            .commit();
+        if (calendarMinDate) {
+            this.nativeView.state().edit()
+                .setMinimumDate(new MaterialCalendarDay(calendarMinDate.getFullYear(), calendarMinDate.getMonth(), calendarMinDate.getDate()))
+                .commit();
+        }
     }
 
     [eventsProperty.setNative](newEvents: Array<CalendarEvent>) {
@@ -215,5 +222,17 @@ export class Calendar extends CalendarBase {
 
     private isSameDate(dateOne, dateTwo) {
         return dateOne.getMonth() === dateTwo.getMonth() && dateOne.getDay() === dateTwo.getDate();
+    }
+
+    public selectDate(date: Date) {
+        this.nativeView.setDateSelected(new MaterialCalendarDay(date.getFullYear(), date.getMonth(), date.getDate()), true);
+    }
+
+    public deselectDate(date: Date) {
+        this.nativeView.setDateSelected(new MaterialCalendarDay(date.getFullYear(), date.getMonth(), date.getDate()), false);
+    }
+
+    public getDate() {
+        return this._date;
     }
 }

--- a/src/ios/calendar.d.ts
+++ b/src/ios/calendar.d.ts
@@ -15,6 +15,7 @@ export declare class CalendarSubtitle {
     text: string;
 }
 export declare class Calendar extends CalendarBase {
+    private _date;
     private _subtitles;
     private _delegate;
     private _dataSource;
@@ -28,11 +29,14 @@ export declare class Calendar extends CalendarBase {
     setCalendarHeightConstraint(height: number): void;
     subtitles: Array<CalendarSubtitle>;
     dateSelectedEvent(date: any): void;
-    pageChanged(calendar: any): void;
+    pageChanged(calendar: any, date: any): void;
     dateHasEvent(date: any): number;
     dateHasEventImage(date: any): string;
     dateHasSubtitle(date: any): string;
     private isSameDate(dateOne, dateTwo);
     reload(): void;
     displayModeChanged(bounds: any): void;
+    selectDate(date: any): void;
+    deselectDate(date: any): void;
+    getDate(): Date;
 }

--- a/src/ios/calendar.d.ts
+++ b/src/ios/calendar.d.ts
@@ -15,7 +15,6 @@ export declare class CalendarSubtitle {
     text: string;
 }
 export declare class Calendar extends CalendarBase {
-    private _date;
     private _subtitles;
     private _delegate;
     private _dataSource;
@@ -36,7 +35,6 @@ export declare class Calendar extends CalendarBase {
     private isSameDate(dateOne, dateTwo);
     reload(): void;
     displayModeChanged(bounds: any): void;
-    selectDate(date: any): void;
-    deselectDate(date: any): void;
-    getDate(): Date;
+    selectDate(date: Date): void;
+    deselectDate(date: Date): void;
 }

--- a/src/ios/calendar.ts
+++ b/src/ios/calendar.ts
@@ -79,9 +79,9 @@ class CalendarDelegate extends NSObject {
             this._owner.get().dateSelectedEvent(date);
         }
     }
-    public calendarCurrentMonthDidChange(calendar) {
+    public calendarCurrentPageDidChange(calendar) {
         if (this._owner) {
-            this._owner.get().pageChanged(calendar);
+            this._owner.get().pageChanged(calendar, calendar.currentPage);
         }
     }
     public calendarBoundingRectWillChangeAnimated(calendar: any, bounds: CGRect, animated: boolean): void {
@@ -155,6 +155,7 @@ class CalendarDataSource extends NSObject {
 
 }
 export class Calendar extends CalendarBase {
+    private _date: Date;
     private _subtitles: Array<CalendarSubtitle>;
     private _delegate: CalendarDelegate;
     private _dataSource: CalendarDataSource;
@@ -274,12 +275,13 @@ export class Calendar extends CalendarBase {
         });
     }
 
-    public pageChanged(calendar) {
+    public pageChanged(calendar, date) {
         this.notify({
             eventName: NSEvents.monthChanged,
             object: this,
-            data: calendar
+            data: date
         });
+        this._date = date;
     }
 
     public dateHasEvent(date): number {
@@ -337,5 +339,16 @@ export class Calendar extends CalendarBase {
             object: this,
             data: bounds
         });
+    }
+    public selectDate(date) {
+        this.nativeView.selectDate(date);
+        this._date = date;
+    }
+    public deselectDate(date) {
+        this.nativeView.deselectDate(date);
+        this._date = null;
+    }
+    public getDate() {
+        return this._date;
     }
 }

--- a/src/ios/calendar.ts
+++ b/src/ios/calendar.ts
@@ -155,7 +155,6 @@ class CalendarDataSource extends NSObject {
 
 }
 export class Calendar extends CalendarBase {
-    private _date: Date;
     private _subtitles: Array<CalendarSubtitle>;
     private _delegate: CalendarDelegate;
     private _dataSource: CalendarDataSource;
@@ -281,7 +280,6 @@ export class Calendar extends CalendarBase {
             object: this,
             data: date
         });
-        this._date = date;
     }
 
     public dateHasEvent(date): number {
@@ -340,15 +338,10 @@ export class Calendar extends CalendarBase {
             data: bounds
         });
     }
-    public selectDate(date) {
+    public selectDate(date: Date) {
         this.nativeView.selectDate(date);
-        this._date = date;
     }
-    public deselectDate(date) {
+    public deselectDate(date: Date) {
         this.nativeView.deselectDate(date);
-        this._date = null;
-    }
-    public getDate() {
-        return this._date;
     }
 }


### PR DESCRIPTION
- Get same date format from both Android and iOS platforms
- Fix error if no minimum or maximum date is set for Android
- Programmatically (de)select date and get date (`selectDate()`, `deselecteDate()`, `getDate()`)